### PR TITLE
игнорируем при выгрузке заскипанные тесты и todo

### DIFF
--- a/src/lib/jest/index.ts
+++ b/src/lib/jest/index.ts
@@ -6,9 +6,11 @@ import {
 } from '../domain';
 import { parseObject, readTextFile } from '../utils';
 import { Validator } from '../validators';
-import { JestReport, jestReportDecoder } from './models';
+import { JestAssertionStatus, JestReport, jestReportDecoder } from './models';
 
 export const getFullName = (...parts: string[]) => parts.join(' / ');
+
+export const ignoredStatuses = new Set<JestAssertionStatus>(['pending', 'todo']);
 
 export const applyJestReport = (
   validationContext: Validator,
@@ -20,7 +22,9 @@ export const applyJestReport = (
 
   // формируем список ключей тест-кейсов из отчета jest
   for (let { assertionResults, name: path } of report.testResults) {
-    for (let { title, ancestorTitles } of assertionResults) {
+    const assertions = assertionResults.filter(a => !ignoredStatuses.has(a.status));
+
+    for (let { title, ancestorTitles } of assertions) {
       const name = getFullName(...ancestorTitles, title);
       const pathes = names.get(name) || [];
       pathes.push(path);

--- a/src/lib/jest/models.ts
+++ b/src/lib/jest/models.ts
@@ -10,7 +10,8 @@ export const jestSuiteStatusDecoder = d.literal(
 export const jestAssertionStatusDecoder = d.literal(
   "passed",
   "failed",
-  "pending"
+  "pending",
+  "todo",
 );
 
 export const jestAssertionResultDecoder = d.struct({
@@ -36,3 +37,4 @@ export const jestReportDecoder = d.struct({
 });
 
 export type JestReport = d.TypeOf<typeof jestReportDecoder>;
+export type JestAssertionStatus = d.TypeOf<typeof jestAssertionStatusDecoder>;


### PR DESCRIPTION
Суть изменений:
- поддержал в синхронизаторе статус `todo` у тестов (раньше на таких тестах синхронизатор падал с ошибкой "неизвестный статус")
- исключил заскипанные тесты и todo из выгрузки — сейчас считается, как будто этих тестов нет (то же самое, что тесты не написаны)